### PR TITLE
Get simple tables working

### DIFF
--- a/html2docx/builder.py
+++ b/html2docx/builder.py
@@ -46,10 +46,6 @@ class ParagraphParser(object):
                 ooxml_style = self.html_to_ooxml_tag_conversions.get(style)
                 if ooxml_style:
                     setattr(run.properties, ooxml_style, True)
-            if 'strong' in styles:
-                run.properties.bold = True
-            if 'em' in styles:
-                run.properties.italics = True
             yield run
 
     @property

--- a/html2docx/builder.py
+++ b/html2docx/builder.py
@@ -132,12 +132,37 @@ class RunProperties(BaseTag):
             self._italics = False
 
 
+class TableParser(BaseParser):
+    @property
+    def tag(self):
+        table_rows = []
+        for table_row in self.element.findall('tr'):
+            table_rows.append(TableRowParser(table_row))
+        return Table(table_rows)
+
+
+class Table(BaseTag):
+    tag_name = 'w:tbl'
+
+    def __init__(self, table_rows=None):
+        self.table_rows = table_rows
+
+    @property
+    def tree(self):
+        element = cElementTree.Element(self.tag_name)
+        if self.table_rows is None:
+            return element
+        for table_row in self.table_rows:
+            element.append(table_row.tag.tree)
+        return element
+
+
 class TableRowParser(BaseParser):
     @property
     def tag(self):
         table_cells = []
-        for table_row in self.element.findall('td'):
-            table_cells.append(TableCellParser(table_row))
+        for table_cell in self.element.findall('td'):
+            table_cells.append(TableCellParser(table_cell))
         return TableRow(table_cells)
 
 

--- a/html2docx/builder.py
+++ b/html2docx/builder.py
@@ -132,6 +132,31 @@ class RunProperties(BaseTag):
             self._italics = False
 
 
+class TableRowParser(BaseParser):
+    @property
+    def tag(self):
+        table_cells = []
+        for table_row in self.element.findall('td'):
+            table_cells.append(TableCellParser(table_row))
+        return TableRow(table_cells)
+
+
+class TableRow(BaseTag):
+    tag_name = 'w:tr'
+
+    def __init__(self, table_cells=None):
+        self.table_cells = table_cells
+
+    @property
+    def tree(self):
+        element = cElementTree.Element(self.tag_name)
+        if self.table_cells is None:
+            return element
+        for table_cell in self.table_cells:
+            element.append(table_cell.tag.tree)
+        return element
+
+
 class TableCellParser(BaseParser):
     @property
     def tag(self):

--- a/html2docx/core.py
+++ b/html2docx/core.py
@@ -3,7 +3,13 @@ from xml.etree import cElementTree
 from jinja2 import Environment, PackageLoader
 
 from html2docx.utils import ZipFile
-from html2docx.builder import ParagraphParser
+from html2docx.builder import ParagraphParser, TableParser
+
+
+tag_to_parser_conversions = {
+    'p': ParagraphParser,
+    'table': TableParser
+}
 
 
 class HTML2Docx(object):
@@ -47,8 +53,9 @@ class HTML2Docx(object):
             if el in self.visited:
                 continue
             self.visited.update([el])
-            if el.tag == 'p':
-                parser = ParagraphParser(el)
+            Parser = tag_to_parser_conversions.get(el.tag)
+            if Parser:
+                parser = Parser(el)
                 self.document_state.append(parser.tag)
                 self.visited.update(el.getiterator())
 

--- a/html2docx/tests/__init__.py
+++ b/html2docx/tests/__init__.py
@@ -56,6 +56,9 @@ class TestDocx2Html(Docx2Html):
     def style(*args, **kwargs):
         return ''
 
+    def table(self, text):
+        return '<table>%s</table>' % text
+
 
 def build_run(test_name, html):
     boiler_plate = '<html><head></head><body>%s</body></html>'

--- a/html2docx/tests/test_builder.py
+++ b/html2docx/tests/test_builder.py
@@ -5,8 +5,10 @@ from html2docx.builder import (
     Paragraph,
     ParagraphParser,
     RunProperties,
+    Table,
     TableCell,
     TableCellParser,
+    TableParser,
     TableRow,
     TableRowParser,
 )
@@ -142,6 +144,41 @@ class TableRowTestCase(TestCase):
     def test_empty(self):
         table_row = TableRow()
         expected_xml = '<w:tr />'
+
+        xml = table_row.xml
+        self.assertEqual(xml, expected_xml)
+
+
+class TableParserTestCase(TestCase):
+    def test_simple(self):
+        element = cElementTree.fromstring('<table><tr><td>AAA</td></tr></table>')  # noqa
+        parser = TableParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tbl><w:tr><w:tc><w:p><w:r><w:rPr /><w:t>AAA</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'  # noqa
+
+        self.assertEqual(xml, expected_xml)
+
+    def test_with_style(self):
+        element = cElementTree.fromstring('<table><tr><td><strong>AAA</strong></td></tr></table>')  # noqa
+        parser = TableParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tbl><w:tr><w:tc><w:p><w:r><w:rPr><w:b /></w:rPr><w:t>AAA</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'  # noqa
+
+        self.assertEqual(xml, expected_xml)
+
+    def test_multiple_cells(self):
+        element = cElementTree.fromstring('<table><tr><td>AAA</td><td>BBB</td></tr><tr><td>CCC</td><td>DDD</td></tr></table>')  # noqa
+        parser = TableParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tbl><w:tr><w:tc><w:p><w:r><w:rPr /><w:t>AAA</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rPr /><w:t>BBB</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:rPr /><w:t>CCC</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rPr /><w:t>DDD</w:t></w:r></w:p></w:tc></w:tr></w:tbl>'  # noqa
+
+        self.assertEqual(xml, expected_xml)
+
+
+class TableTestCase(TestCase):
+    def test_empty(self):
+        table_row = Table()
+        expected_xml = '<w:tbl />'
 
         xml = table_row.xml
         self.assertEqual(xml, expected_xml)

--- a/html2docx/tests/test_builder.py
+++ b/html2docx/tests/test_builder.py
@@ -1,7 +1,12 @@
 from xml.etree import cElementTree
 from unittest import TestCase
 
-from html2docx.builder import RunProperties, ParagraphParser, Paragraph
+from html2docx.builder import (
+    Paragraph,
+    ParagraphParser,
+    RunProperties,
+    TableCell,
+)
 
 
 class RunPropertiesTestCase(TestCase):
@@ -74,4 +79,13 @@ class ParagraphTestCase(TestCase):
         expected_xml = '<w:p />'
 
         xml = paragraph.xml
+        self.assertEqual(xml, expected_xml)
+
+
+class TableCellTestCase(TestCase):
+    def test_empty(self):
+        table_cell = TableCell()
+        expected_xml = '<w:tc />'
+
+        xml = table_cell.xml
         self.assertEqual(xml, expected_xml)

--- a/html2docx/tests/test_builder.py
+++ b/html2docx/tests/test_builder.py
@@ -83,14 +83,7 @@ class ParagraphTestCase(TestCase):
         self.assertEqual(xml, expected_xml)
 
 
-class TableCellTestCase(TestCase):
-    def test_empty(self):
-        table_cell = TableCell()
-        expected_xml = '<w:tc />'
-
-        xml = table_cell.xml
-        self.assertEqual(xml, expected_xml)
-
+class TableCellParserTestCase(TestCase):
     def test_simple(self):
         element = cElementTree.fromstring('<td>AAA</td>')
         parser = TableCellParser(element)
@@ -105,4 +98,13 @@ class TableCellTestCase(TestCase):
         xml = parser.tag.xml
         expected_xml = '<w:tc><w:p><w:r><w:rPr><w:b /></w:rPr><w:t>AAA</w:t></w:r></w:p></w:tc>'  # noqa
 
+        self.assertEqual(xml, expected_xml)
+
+
+class TableCellTestCase(TestCase):
+    def test_empty(self):
+        table_cell = TableCell()
+        expected_xml = '<w:tc />'
+
+        xml = table_cell.xml
         self.assertEqual(xml, expected_xml)

--- a/html2docx/tests/test_builder.py
+++ b/html2docx/tests/test_builder.py
@@ -7,6 +7,7 @@ from html2docx.builder import (
     RunProperties,
     TableCell,
     TableCellParser,
+    TableRowParser,
 )
 
 
@@ -107,4 +108,30 @@ class TableCellTestCase(TestCase):
         expected_xml = '<w:tc />'
 
         xml = table_cell.xml
+        self.assertEqual(xml, expected_xml)
+
+
+class TableRowParserTestCase(TestCase):
+    def test_simple(self):
+        element = cElementTree.fromstring('<tr><td>AAA</td></tr>')
+        parser = TableRowParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tr><w:tc><w:p><w:r><w:rPr /><w:t>AAA</w:t></w:r></w:p></w:tc></w:tr>'  # noqa
+
+        self.assertEqual(xml, expected_xml)
+
+    def test_with_style(self):
+        element = cElementTree.fromstring('<tr><td><strong>AAA</strong></td></tr>')  # noqa
+        parser = TableRowParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tr><w:tc><w:p><w:r><w:rPr><w:b /></w:rPr><w:t>AAA</w:t></w:r></w:p></w:tc></w:tr>'  # noqa
+
+        self.assertEqual(xml, expected_xml)
+
+    def test_multiple_cells(self):
+        element = cElementTree.fromstring('<tr><td>AAA</td><td>BBB</td></tr>')
+        parser = TableRowParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tr><w:tc><w:p><w:r><w:rPr /><w:t>AAA</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rPr /><w:t>BBB</w:t></w:r></w:p></w:tc></w:tr>'  # noqa
+
         self.assertEqual(xml, expected_xml)

--- a/html2docx/tests/test_builder.py
+++ b/html2docx/tests/test_builder.py
@@ -7,6 +7,7 @@ from html2docx.builder import (
     RunProperties,
     TableCell,
     TableCellParser,
+    TableRow,
     TableRowParser,
 )
 
@@ -134,4 +135,13 @@ class TableRowParserTestCase(TestCase):
         xml = parser.tag.xml
         expected_xml = '<w:tr><w:tc><w:p><w:r><w:rPr /><w:t>AAA</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rPr /><w:t>BBB</w:t></w:r></w:p></w:tc></w:tr>'  # noqa
 
+        self.assertEqual(xml, expected_xml)
+
+
+class TableRowTestCase(TestCase):
+    def test_empty(self):
+        table_row = TableRow()
+        expected_xml = '<w:tr />'
+
+        xml = table_row.xml
         self.assertEqual(xml, expected_xml)

--- a/html2docx/tests/test_builder.py
+++ b/html2docx/tests/test_builder.py
@@ -6,6 +6,7 @@ from html2docx.builder import (
     ParagraphParser,
     RunProperties,
     TableCell,
+    TableCellParser,
 )
 
 
@@ -88,4 +89,20 @@ class TableCellTestCase(TestCase):
         expected_xml = '<w:tc />'
 
         xml = table_cell.xml
+        self.assertEqual(xml, expected_xml)
+
+    def test_simple(self):
+        element = cElementTree.fromstring('<td>AAA</td>')
+        parser = TableCellParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tc><w:p><w:r><w:rPr /><w:t>AAA</w:t></w:r></w:p></w:tc>'  # noqa
+
+        self.assertEqual(xml, expected_xml)
+
+    def test_with_style(self):
+        element = cElementTree.fromstring('<td><strong>AAA</strong></td>')
+        parser = TableCellParser(element)
+        xml = parser.tag.xml
+        expected_xml = '<w:tc><w:p><w:r><w:rPr><w:b /></w:rPr><w:t>AAA</w:t></w:r></w:p></w:tc>'  # noqa
+
         self.assertEqual(xml, expected_xml)

--- a/html2docx/tests/test_complex.py
+++ b/html2docx/tests/test_complex.py
@@ -1,0 +1,24 @@
+from html2docx.tests import build_run
+
+
+test_cases = [
+    (
+        'Test paragraph, table, paragraph.',
+        '<p>AAA</p><table><tr><td>BBB</td></tr></table><p>CCC</p>',
+    ),
+    (
+        'Test table, table, paragraph',
+        '<table><tr><td>AAA</td></tr></table><table><tr><td>BBB</td></tr></table><p>CCC</p>',  # noqa
+    ),
+    # Nesting doesn't really work yet.
+    # (
+    #     'Test Nested Table',
+    #     '<table><tr><td>AAA</td><td><table><tr><td>BBB</td></tr></table></td></tr></table>',  # noqa
+    # ),
+]
+
+
+def test():
+    for test_name, html in test_cases:
+        run = build_run(test_name, html)
+        yield run

--- a/html2docx/tests/test_tables.py
+++ b/html2docx/tests/test_tables.py
@@ -6,6 +6,18 @@ test_cases = [
         'Test simple table.',
         '<table><tr><td>AAA</td></tr></table>',
     ),
+    (
+        'Test multiple rows.',
+        '<table><tr><td>AAA</td></tr><tr><td>BBB</td></tr></table>',
+    ),
+    (
+        'Test multiple cells.',
+        '<table><tr><td>AAA</td><td>BBB</td></tr></table>',
+    ),
+    (
+        'Test multiple rows and cells.',
+        '<table><tr><td>AAA</td><td>BBB</td></tr><tr><td>CCC</td><td>DDD</td></tr></table>',  # noqa
+    ),
 ]
 
 

--- a/html2docx/tests/test_tables.py
+++ b/html2docx/tests/test_tables.py
@@ -1,0 +1,15 @@
+from html2docx.tests import build_run
+
+
+test_cases = [
+    (
+        'Test simple table.',
+        '<table><tr><td>AAA</td></tr></table>',
+    ),
+]
+
+
+def test():
+    for test_name, html in test_cases:
+        run = build_run(test_name, html)
+        yield run

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-nosetests -v -v --with-coverage --cover-erase --cover-package=. html2docx && find -name '*.py' | xargs flake8
+nosetests -v -v --with-coverage --cover-erase --cover-package=html2docx html2docx && find -name '*.py' | xargs flake8

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,3 @@
 #! /bin/sh
 
-RUN_TESTS='nosetests -v -v --with-coverage --cover-erase --cover-package=. html2docx'
-echo $RUN_TESTS
-$RUN_TESTS
+nosetests -v -v --with-coverage --cover-erase --cover-package=. html2docx && find -name '*.py' | xargs flake8


### PR DESCRIPTION
No `rowspan` or `colspan`. Just implement:
- `table`
- `tr`
- `td`
